### PR TITLE
Return unit64 based timestamp in packet timeout error message

### DIFF
--- a/modules/core/04-channel/keeper/packet.go
+++ b/modules/core/04-channel/keeper/packet.go
@@ -98,10 +98,7 @@ func (k Keeper) SendPacket(
 		}
 
 		if packet.GetTimeoutTimestamp() != 0 && latestTimestamp >= packet.GetTimeoutTimestamp() {
-			return sdkerrors.Wrapf(
-				types.ErrPacketTimeout,
-				"receiving chain block timestamp >= packet timeout timestamp (%s >= %s)", time.Unix(0, int64(latestTimestamp)), time.Unix(0, int64(packet.GetTimeoutTimestamp())),
-			)
+			return GetPacketTimeoutErrorMessage(latestTimestamp, packet.GetTimeoutTimestamp())
 		}
 	}
 
@@ -138,6 +135,15 @@ func (k Keeper) SendPacket(
 	)
 
 	return nil
+}
+
+func GetPacketTimeoutErrorMessage(latestTimestamp uint64, timeoutTimestamp uint64) error {
+	return sdkerrors.Wrapf(
+		types.ErrPacketTimeout,
+		"receiving chain block timestamp >= packet timeout timestamp (%d >= %d)",
+		latestTimestamp,
+		timeoutTimestamp,
+	)
 }
 
 // RecvPacket is called by a module in order to receive & process an IBC packet

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -886,11 +886,6 @@ func TestGetPacketTimeoutErrorMessage(t *testing.T) {
 			args{30, 20},
 			"receiving chain block timestamp >= packet timeout timestamp (30 >= 20): packet timeout",
 		},
-		{
-			"error message is returned",
-			args{-1, 30},
-			"receiving chain block timestamp >= packet timeout timestamp (30 >= 30): packet timeout",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -874,6 +874,7 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 
 func TestGetPacketTimeoutErrorMessage(t *testing.T) {
 	type args struct {
+		message          string
 		latestTimestamp  uint64
 		timeoutTimestamp uint64
 	}
@@ -882,14 +883,27 @@ func TestGetPacketTimeoutErrorMessage(t *testing.T) {
 		args       args
 		wantErrMsg string
 	}{
-		{"error message is returned",
-			args{30, 20},
+		{"receiving chain block timestamp error message is returned",
+			args{
+				"receiving chain block timestamp >= packet timeout timestamp (%d >= %d)",
+				30,
+				20,
+			},
 			"receiving chain block timestamp >= packet timeout timestamp (30 >= 20): packet timeout",
+		},
+		{
+			"block timestamp error message is returned",
+			args{
+				"block timestamp >= packet timeout timestamp (%d >= %d)",
+				100,
+				50,
+			},
+			"block timestamp >= packet timeout timestamp (100 >= 50): packet timeout",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := keeper.GetPacketTimeoutErrorMessage(tt.args.latestTimestamp, tt.args.timeoutTimestamp)
+			err := keeper.GetPacketTimeoutErrorMessage(tt.args.message, tt.args.latestTimestamp, tt.args.timeoutTimestamp)
 			require.Error(t, err)
 			require.Equal(t, tt.wantErrMsg, err.Error())
 		})

--- a/modules/core/04-channel/keeper/packet_test.go
+++ b/modules/core/04-channel/keeper/packet_test.go
@@ -3,6 +3,9 @@ package keeper_test
 import (
 	"errors"
 	"fmt"
+	"github.com/cosmos/ibc-go/v3/modules/core/04-channel/keeper"
+	"github.com/stretchr/testify/require"
+	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
@@ -865,6 +868,35 @@ func (suite *KeeperTestSuite) TestAcknowledgePacket() {
 					suite.Require().True(errors.Is(err, expError))
 				}
 			}
+		})
+	}
+}
+
+func TestGetPacketTimeoutErrorMessage(t *testing.T) {
+	type args struct {
+		latestTimestamp  uint64
+		timeoutTimestamp uint64
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantErrMsg string
+	}{
+		{"error message is returned",
+			args{30, 20},
+			"receiving chain block timestamp >= packet timeout timestamp (30 >= 20): packet timeout",
+		},
+		{
+			"error message is returned",
+			args{-1, 30},
+			"receiving chain block timestamp >= packet timeout timestamp (30 >= 30): packet timeout",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := keeper.GetPacketTimeoutErrorMessage(tt.args.latestTimestamp, tt.args.timeoutTimestamp)
+			require.Error(t, err)
+			require.Equal(t, tt.wantErrMsg, err.Error())
 		})
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

IBC packet time out message is returned as time.Unix which converts to a local server time. This leads to non-determinism when we persist this error message. 
This PR switches to returning uint64 based timestamps.

Testing
- unit test
